### PR TITLE
Bumped `brs-engine` to v2.0.0-alpha.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Simple Code Editor for playing with BrightScript language.
 
-[![Version 2.0.5](https://img.shields.io/badge/Version-2.0.5-blue.svg)](https://github.com/lvcabral/brs-fiddle/releases/tag/v2.0.5)
+[![Version 2.0.6](https://img.shields.io/badge/Version-2.0.6-blue.svg)](https://github.com/lvcabral/brs-fiddle/releases/tag/v2.0.6)
 [![Build and Deploy](https://github.com/lvcabral/brs-fiddle/actions/workflows/build-github.yml/badge.svg)](https://github.com/lvcabral/brs-fiddle/actions/workflows/build-github.yml)
 [![GitHub](https://img.shields.io/github/license/lvcabral/brs-fiddle)](./LICENSE)
 [![Slack](https://img.shields.io/badge/Slack-RokuCommunity-4A154B?logo=slack)](https://join.slack.com/t/rokudevelopers/shared_invite/zt-4vw7rg6v-NH46oY7hTktpRIBM_zGvwA)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brs-fiddle",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "BrightScript Fiddle",
   "author": "Marcelo Lv Cabral <marcelo@lvcabral.com> (https://lvcabral.com/)",
   "homepage": "https://lvcabral.com/brs/",
@@ -33,7 +33,7 @@
     "@zenfs/archives": "1.0.5",
     "@zenfs/core": "^1.11.4",
     "@zenfs/dom": "1.1.5",
-    "brs-engine": "^2.0.0-alpha.8",
+    "brs-engine": "^2.0.0-alpha.9",
     "codemirror": "^5.65.12",
     "fflate": "^0.8.2",
     "file-saver": "^2.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1011,10 +1011,10 @@ browserslist@^4.24.0:
     node-releases "^2.0.19"
     update-browserslist-db "^1.1.3"
 
-brs-engine@^2.0.0-alpha.8:
-  version "2.0.0-alpha.8"
-  resolved "https://registry.yarnpkg.com/brs-engine/-/brs-engine-2.0.0-alpha.8.tgz#816722ed27c31971ac4b1ae3a425bc35384a3d09"
-  integrity sha512-0Cr9FnWCT0FslBQlE4vgEE3s/jMSCOPhR7CJWyRbSuaG8+kBzxIn7gYVchF+CO43+4xymqO61MajUff6i4IDHA==
+brs-engine@^2.0.0-alpha.9:
+  version "2.0.0-alpha.9"
+  resolved "https://registry.yarnpkg.com/brs-engine/-/brs-engine-2.0.0-alpha.9.tgz#05298a153bda8ca5c7a25a97eaff6a69ece4b832"
+  integrity sha512-CwTUa1bSOHOXguf0W3M002LMlp/WXEFxbsR6OFgilod3Lfd7NhrjW6g7cRGMxzewVRT+/WtA7gpW7T+72OtweA==
   dependencies:
     "@lvcabral/libwebp" "^0.1.0"
     "@lvcabral/memory-fs" "^0.5.1"


### PR DESCRIPTION
Includes a couple of fixes for node creation